### PR TITLE
Add python38 support for Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,15 @@ language: python
 python:
   - "3.6"
   - "3.7"
+  - "3.8"
 branches:
   only:
   - master
   - develop
   - /^release-.*$/
+  - /^beta-.*$/
 install:
   - pip install -r requirements_dev.txt
 script:
-  - nosetests --with-coverage --cover-package borax
+  - nose2 --with-coverage --coverage borax
   - flake8 borax tests

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-nose==1.3.7
+nose2==0.9.1
 coverage==5.0.1
 flake8==3.7.9
 mccabe==0.6.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 nose==1.3.7
-coverage==4.4.1
-flake8==3.6.0
+coverage==5.0.1
+flake8==3.7.9
 mccabe==0.6.1
-wheel==0.31.1
+wheel==0.33.6


### PR DESCRIPTION
changes:
- Add python3.8
- use `nose2` instead of `nose`
- update build package