### PR TITLE
:bug: Fix upper value for StringSerialGenerator

### DIFF
--- a/borax/counters/serials.py
+++ b/borax/counters/serials.py
@@ -64,7 +64,7 @@ class StringSerialGenerator(SerialGenerator):
             raise ValueError('Invalid base value {}.Choices are: 2, 8, 10, 16'.format(base))
         self._num_fmt = '{{0:0{0}{1}}}'.format(digits, num_fmt[base])
         self._base = base
-        super().__init__(lower=0, upper=self._base ** digits - 1)
+        super().__init__(lower=0, upper=self._base ** digits)
 
     def generate(self, num: int) -> List[str]:
         res = super().generate(num)

--- a/tests/test_serial_generattor.py
+++ b/tests/test_serial_generattor.py
@@ -52,3 +52,9 @@ class StringSerialGeneratorTestCase(unittest.TestCase):
     def test_error_base(self):
         with self.assertRaises(ValueError):
             StringSerialGenerator(prefix='CC', digits=2, base=3)
+
+    def test_upper_edge_value(self):
+        ssg = StringSerialGenerator(prefix='ff', digits=1, base=10)
+        data = ssg.generate(num=10)
+        self.assertEqual(10, len(data))
+        self.assertEqual('ff9', data[-1])


### PR DESCRIPTION
BUG重现

```python
from borax.counters.serials import  StringSerialGenerator

ssg = StringSerialGenerator(prefix='ff', digits=1, base=10)
data = ssg.generate(num=10)

print(data)
```
结果
```
Traceback (most recent call last):
  File "E:\PycharmProjects\radon\demo.py", line 6, in <module>
    data = ssg.generate(num=10)
  File "D:\Python37\lib\site-packages\borax\counters\serials.py", line 70, in generate
    res = super().generate(num)
  File "D:\Python37\lib\site-packages\borax\counters\serials.py", line 38, in generate
    result = generate_serials(upper=self._upper, lower=self._lower, num=num, serials=self._data_set)
  File "D:\Python37\lib\site-packages\borax\counters\serials.py", line 13, in generate_serials
    raise ValueError('Can not generate {} serials in [{}, {}].'.format(num, lower, upper))
ValueError: Can not generate 10 serials in [0, 9].
```
