### PR TITLE
:boom: Change the call strategy of function paramters in join_ module

### DIFF
--- a/borax/datasets/join_.py
+++ b/borax/datasets/join_.py
@@ -1,11 +1,13 @@
 # coding=utf8
 
 import operator
+import copy
 
 __all__ = ['join_one', 'join', 'old_join_one', 'old_join']
 
 
 def join_one(ldata, rdata, on, select_as, default=None):
+    ldata = copy.deepcopy(ldata)
     if isinstance(rdata, (list, tuple)):
         rdata = dict(rdata)
     if not isinstance(rdata, dict):
@@ -70,6 +72,7 @@ SC = SelectClause
 
 
 def join(ldata, rdata, on, select_as):
+    ldata = copy.deepcopy(ldata)
     if isinstance(on, CLAUSE_SINGLE_TYPES):
         on = [on]
     if isinstance(on, list):
@@ -104,6 +107,7 @@ def join(ldata, rdata, on, select_as):
 
 
 def old_join_one(data_list, values, from_, as_, default=None):
+    data_list = copy.deepcopy(data_list)
     if isinstance(values, (list, tuple)):
         values = dict(values)
     if not isinstance(values, dict):
@@ -120,6 +124,7 @@ def old_join_one(data_list, values, from_, as_, default=None):
 
 
 def old_join(data_list, values, from_, to_, as_args=None, as_kwargs=None):
+    data_list = copy.deepcopy(data_list)
     as_args = as_args or []
     as_kwargs = as_kwargs or {}
     as_fields = {**{a: a for a in as_args}, **as_kwargs}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,8 @@
   - 新增 `LCalendars.get_leap_years` 函数
   - 新增 `InvalidLunarDateError` 异常类
   - 修正农历平月日期 `%t` 格式化显示的BUG
+- **borax.datasets**
+  - `join` 模块相关函数参数 `ldata` 和 `data_list` 使用赋值传参方式，不再改变原有列表数据的内容
 - **`borax.numbers`**
   - `ChineseNumbers` 类新增 计量/编号 两种数字形式
 - **`borax.htmls`**

--- a/docs/guides/join.md
+++ b/docs/guides/join.md
@@ -6,6 +6,12 @@
 
 ## 重要说明
 
+### Changed in v3.4.0
+
+本模块 `join_*` 相关函数的第一个参数 `ldata` 、`data_list` 改用赋值传参方式，即这些函数不会改变原有的数据内容。
+
+### Changed in v3.2.0
+
 从v3.2.0开始，我们重写 `join` 和 `join_one` ，原有的函数分别重命名为 `old_join` 和 `old_join_one` ，主要变化如下：
 
 - 使用符合SQL的参数命名，比如 on、select_as 等。
@@ -31,8 +37,6 @@ from borax.datasets.join_ import old_join as join, old_join_one as join_one
 本模块实现了类似于数据库的 LEFT JOIN 数据列表操作，从另一个数据集获取某一个或几个列的值，加到当前数据集中。
 
 > **关于LEFT JOIN** ：LEFT JOIN返回左表的全部行和右表满足ON条件的行，如果左表的行在右表中没有匹配，那么这一行右表中对应数据用NULL代替。
-
-本模块的 join_ 函数将会修改传入的列表join_数据，如需不影响原有数据，可以提前复制一份数据。
 
 本模块示例所用的数据描述如下：
 

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -27,36 +27,33 @@ books = [
 
 class JoinOneTestCase(unittest.TestCase):
     def test_with_dict(self):
-        book_data = copy.deepcopy(books)
-        catalog_books = old_join_one(book_data, catalogs_dict, from_='catalog', as_='catalog_name')
+        catalog_books = old_join_one(books, catalogs_dict, from_='catalog', as_='catalog_name')
         self.assertTrue(all(['catalog_name' in book for book in catalog_books]))
         self.assertEqual('Java', catalog_books[1]['catalog_name'])
+        self.assertFalse('catalog_name' in books[1])
 
     def test_with_choices(self):
-        book_data = copy.deepcopy(books)
-        catalog_books = old_join_one(book_data, catalog_choices, from_='catalog', as_='catalog_name')
+        catalog_books = old_join_one(books, catalog_choices, from_='catalog', as_='catalog_name')
         self.assertTrue(all(['catalog_name' in book for book in catalog_books]))
         self.assertEqual('Java', catalog_books[1]['catalog_name'])
 
     def test_join_one_with_default(self):
-        book_data = copy.deepcopy(books)
         cur_catalogs_dict = {
             1: 'Python',
             2: 'Java'
         }
 
-        catalog_books = old_join_one(book_data, cur_catalogs_dict, from_='catalog', as_='catalog_name')
+        catalog_books = old_join_one(books, cur_catalogs_dict, from_='catalog', as_='catalog_name')
         self.assertTrue(all(['catalog_name' in book for book in catalog_books]))
         self.assertEqual(None, catalog_books[2]['catalog_name'])
 
     def test_join_one_with_custom_default(self):
-        book_data = copy.deepcopy(books)
         cur_catalogs_dict = {
             1: 'Python',
             2: 'Java'
         }
 
-        catalog_books = old_join_one(book_data, cur_catalogs_dict, from_='catalog', as_='catalog_name',
+        catalog_books = old_join_one(books, cur_catalogs_dict, from_='catalog', as_='catalog_name',
                                      default='[未知分类]')
         self.assertTrue(all(['catalog_name' in book for book in catalog_books]))
         self.assertEqual('[未知分类]', catalog_books[2]['catalog_name'])
@@ -64,8 +61,8 @@ class JoinOneTestCase(unittest.TestCase):
 
 class JoinTestCase(unittest.TestCase):
     def test_as_kwargs(self):
-        book_data = copy.deepcopy(books)
-        catalog_books = old_join(book_data, catalogs_list, from_='catalog', to_='id',
+        catalog_books = old_join(books, catalogs_list, from_='catalog', to_='id',
                                  as_kwargs={'name': 'catalog_name'})
         self.assertTrue(all(['catalog_name' in book for book in catalog_books]))
         self.assertEqual('Java', catalog_books[1]['catalog_name'])
+        self.assertFalse('catalog_name' in books[1])

--- a/tests/test_new_join.py
+++ b/tests/test_new_join.py
@@ -65,54 +65,53 @@ class SelectClauseTestCase(unittest.TestCase):
 
 class JoinOneTestCase(unittest.TestCase):
     def test_with_dict(self):
-        book_data = copy.deepcopy(books)
-        catalog_books = join_one(book_data, catalogs_dict, on='catalog', select_as='catalog_name')
+        catalog_books = join_one(books, catalogs_dict, on='catalog', select_as='catalog_name')
         self.assertTrue(all(['catalog_name' in book for book in catalog_books]))
         self.assertEqual('Java', catalog_books[1]['catalog_name'])
+        self.assertFalse('catalog_name' in books[1])
 
     def test_with_choices(self):
-        book_data = copy.deepcopy(books)
-
-        catalog_books = join_one(book_data, catalog_choices, on='catalog', select_as='catalog_name')
+        catalog_books = join_one(books, catalog_choices, on='catalog', select_as='catalog_name')
         self.assertTrue(all(['catalog_name' in book for book in catalog_books]))
         self.assertEqual('Java', catalog_books[1]['catalog_name'])
+        self.assertFalse('catalog_name' in books[1])
 
     def test_join_one_with_default(self):
-        book_data = copy.deepcopy(books)
         cur_catalogs_dict = {
             1: 'Python',
             2: 'Java'
         }
 
-        catalog_books = join_one(book_data, cur_catalogs_dict, on='catalog', select_as='catalog_name')
+        catalog_books = join_one(books, cur_catalogs_dict, on='catalog', select_as='catalog_name')
         self.assertTrue(all(['catalog_name' in book for book in catalog_books]))
         self.assertEqual(None, catalog_books[2]['catalog_name'])
+        self.assertFalse('catalog_name' in books[1])
 
     def test_join_one_with_custom_default(self):
-        book_data = copy.deepcopy(books)
         cur_catalogs_dict = {
             1: 'Python',
             2: 'Java'
         }
-        catalog_books = join_one(book_data, cur_catalogs_dict, on='catalog', select_as='catalog_name',
+        catalog_books = join_one(books, cur_catalogs_dict, on='catalog', select_as='catalog_name',
                                  default='[未知分类]')
         self.assertTrue(all(['catalog_name' in book for book in catalog_books]))
         self.assertEqual('[未知分类]', catalog_books[2]['catalog_name'])
+        self.assertFalse('catalog_name' in books[1])
 
     def test_callback(self):
         def _on(_litem):
             return _litem['catalog']
 
-        book_data = copy.deepcopy(books)
-        catalog_books = join_one(book_data, catalogs_dict, on=_on, select_as='catalog_name')
+        catalog_books = join_one(books, catalogs_dict, on=_on, select_as='catalog_name')
         self.assertTrue(all(['catalog_name' in book for book in catalog_books]))
         self.assertEqual('Java', catalog_books[1]['catalog_name'])
+        self.assertFalse('catalog_name' in books[1])
 
 
 class JoinTestCase(unittest.TestCase):
     def test_basic_join(self):
-        book_data = copy.deepcopy(books)
-        catalog_books = join(book_data, catalogs_list, on=('catalog', 'id'),
+        catalog_books = join(books, catalogs_list, on=('catalog', 'id'),
                              select_as=('name', 'catalog_name'))
         self.assertTrue(all(['catalog_name' in book for book in catalog_books]))
         self.assertEqual('Java', catalog_books[1]['catalog_name'])
+        self.assertFalse('catalog_name' in books[1])


### PR DESCRIPTION
This PR introduces a break features which changes the call strategy of function parameters in`borax.datasets.join_` module.  

After applying this PR , `join_one` function will not change the content of the origin *ldata* parameter.As a result , it is unnecessary use `copy.deepcopy` before calling.